### PR TITLE
remove pre-release status from release

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -39,7 +39,7 @@ go get github.com/itchio/gothub; else exit;
 fi
 
 #create the release
-gothub release --tag $TAG -p
+gothub release --tag $TAG
 
 #Upload asset
 gothub upload --tag $TAG --name "usfmsetup.exe" --file ./Output/usfmsetup.exe


### PR DESCRIPTION
Mark would like us to move this to full release status. This PR would do that as long as it is pulled in with a fresh tag.